### PR TITLE
Some small improvements

### DIFF
--- a/effect/src/index.ts
+++ b/effect/src/index.ts
@@ -2,12 +2,12 @@ import { Effect } from "./prelude.js";
 import { Maybe } from "./prelude.js";
 
 export const isPositive = (n: number) =>
-  n > 0 ? Maybe.just("positive") : Maybe.nothing()
+  n > 0 ? Maybe.just("positive") : Maybe.nothing();
 
 export const isPositiveEff = (n: number) =>
-  n > 0 ? Effect("positive") : Effect.fail("negative")
+  n > 0 ? Effect("positive") : Effect.fail("negative");
 
-export const resultEither = isPositive(0).match(() => "nope", () => "yeah")
+export const resultEither = isPositive(0).match(() => "nope", () => "yeah");
 
 export const prog = Effect.do
   .bind("a", () => Effect(0))
@@ -15,9 +15,9 @@ export const prog = Effect.do
   .bind("c", () => Effect(2))
   .bind("d", () => Effect(4) + Effect(5))
   .map(({ a, b, c, d: { tuple: [e, f] } }) => `result: ${a + b + c} ${e} ${f}`)
-  .flatMap((s) => Effect(console.log(s)))
+  .flatMap((s) => Effect(console.log(s)));
 
-export const result = prog | Effect.fail("error")
+export const result = prog | Effect.fail("error");
 
 prog.unsafeRunPromise()
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-    "name": "@effect-ts/typescript-extension",
+    "name": "typescript",
     "version": "4.6.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
-            "name": "@effect-ts/typescript-extension",
+            "name": "typescript",
             "version": "4.6.0",
             "license": "Apache-2.0",
             "bin": {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -42776,22 +42776,21 @@ namespace ts {
         function getEtsFluentSymbol(name: string, dataFirst: FunctionDeclaration) {
             const type = getTypeOfNode(dataFirst);
             const signatures = getSignaturesOfType(type, SignatureKind.Call);
-            const method = etsThisifySignature(signatures[0]);
+            const methods = signatures.map(etsThisifySignature);
             const symbol = createSymbol(SymbolFlags.Function, name as __String);
             symbol.declarations = [dataFirst];
             symbol.valueDeclaration = dataFirst;
             symbol.parent = dataFirst.symbol.parent;
-            const final = createAnonymousType(symbol, emptySymbols, [method], [], []);
+            const final = createAnonymousType(symbol, emptySymbols, methods, [], []);
             return createSymbolWithType(symbol, final);
         }
         function getEtsStaticSymbol(name: string, dataFirst: FunctionDeclaration) {
             const signatures = getSignaturesOfType(getTypeOfNode(dataFirst), SignatureKind.Call);
-            const call = signatures[0];
-            const method = cloneSignature(call);
+            const methods = signatures.map(cloneSignature);
             const symbol = createSymbol(SymbolFlags.Function, name as __String);
             symbol.declarations = [dataFirst];
             symbol.parent = dataFirst.symbol.parent;
-            const final = createAnonymousType(symbol, emptySymbols, [method], [], []);
+            const final = createAnonymousType(symbol, emptySymbols, methods, [], []);
             return createSymbolWithType(symbol, final);
         }
         function etsInitTypeChecker() {

--- a/src/services/goToDefinition.ts
+++ b/src/services/goToDefinition.ts
@@ -49,12 +49,28 @@ namespace ts.GoToDefinition {
                 const staticSymbol = typeChecker.getStaticExtension(type, name);
                 if(staticSymbol && !isCallExpression(parent.parent)) {
                     const declaration = staticSymbol.patched.valueDeclaration!;
+                    let start: number;
+                    let length: number;
+                    if(declaration.original && isNamedDeclaration(declaration.original)) {
+                        start = declaration.original.name.getStart();
+                        length = declaration.original.getWidth();
+                    }
+                    else if(isNamedDeclaration(declaration)) {
+                        start = declaration.name.getStart();
+                        length = declaration.getWidth();
+                    }
+                    else {
+                        start = declaration.getStart();
+                        length = declaration.getWidth();
+                    }
+
+                    if(start === -1 || length === -1) {
+                        return undefined;
+                    }
+
                     return [{
                         fileName: staticSymbol.definition.fileName,
-                        textSpan: {
-                            start: declaration.pos + 1,
-                            length: declaration.end - declaration.pos
-                        },
+                        textSpan: { start, length },
                         kind: SymbolDisplay.getSymbolKind(typeChecker, staticSymbol.patched, node),
                         name: typeChecker.symbolToString(staticSymbol.patched),
                         containerKind: undefined!,


### PR DESCRIPTION
## Changelog

- removed `__etsTrace` from quickinfo (hover)
- allowed overloaded functions in fluent extensions
  - previous behavior was to pick the first overload
- improved `goToDefinition` for non-call-expression fluent static extensions