### PR TITLE
Allow @ets type declarations in modules; fluent variable declarations

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3301,29 +3301,39 @@ namespace ts {
 
     export const enum EtsSymbolTag {
         Fluent = "EtsFluentSymbol",
+        FluentVariable = "EtsFluentVariableSymbol",
         Static = "EtsStaticSymbol",
         Getter = "EtsGetterSymbol"
     }
 
     export interface EtsFluentSymbol extends TransientSymbol {
         etsTag: EtsSymbolTag.Fluent
-        etsDataFirstDeclaration: FunctionDeclaration;
+        etsDeclaration: FunctionDeclaration;
         etsResolvedSignatures: Signature[];
+    }
+
+    export type SignatureWithParameters = Omit<Signature, "parameters"> & { parameters: ReadonlyArray<Symbol & { valueDeclaration: ParameterDeclaration }> }
+
+    export interface EtsFluentVariableSymbol extends TransientSymbol {
+        etsTag: EtsSymbolTag.FluentVariable;
+        etsDeclaration: VariableDeclaration & { name: Identifier };
+        etsParameters: ReadonlyArray<ParameterDeclaration>;
+        etsResolvedSignatures: SignatureWithParameters[];
     }
 
     export interface EtsStaticSymbol extends TransientSymbol {
         etsTag: EtsSymbolTag.Static;
-        etsDataFirstDeclaration: FunctionDeclaration;
+        etsDeclaration: FunctionDeclaration;
         etsResolvedSignatures: Signature[];
     }
 
     export interface EtsGetterSymbol extends TransientSymbol {
         etsTag: EtsSymbolTag.Getter;
         etsSelfType: Type;
-        etsDataFirstDeclaration: FunctionDeclaration;
+        etsDeclaration: FunctionDeclaration;
     }
 
-    export type EtsSymbol = EtsFluentSymbol | EtsStaticSymbol | EtsGetterSymbol;
+    export type EtsSymbol = EtsFluentSymbol | EtsStaticSymbol | EtsGetterSymbol | EtsFluentVariableSymbol;
 
     export interface JSDocLink extends Node {
         readonly kind: SyntaxKind.JSDocLink;

--- a/src/services/goToDefinition.ts
+++ b/src/services/goToDefinition.ts
@@ -45,7 +45,7 @@ namespace ts.GoToDefinition {
         if(isPropertyAccessExpression(parent)) {
             const nodeType = typeChecker.getTypeAtLocation(node);
             if(nodeType.symbol && isEtsSymbol(nodeType.symbol)) {
-                symbol = nodeType.symbol.etsDataFirstDeclaration.symbol;
+                symbol = nodeType.symbol.etsDeclaration.symbol;
             } else {
                 const type = typeChecker.getTypeAtLocation(parent.expression);
                 const extensions = typeChecker.getExtensions(type);


### PR DESCRIPTION
This PR adds the ability to declare `@ets type` inside module augmentations, which could be used to add fluent to built-ins like `Array`. It also adds the ability to declare `@ets fluent` declarations on variable declarations, which could be useful for things like

```ts
/**
 * @ets fluent Effect bind
 */
export const bind_ = P.bindF_(Effect.Monad)
```